### PR TITLE
vectorscope: Add I-Q lines and set it as the default

### DIFF
--- a/doc/vectorscope.md
+++ b/doc/vectorscope.md
@@ -34,7 +34,8 @@ Choice of graticule.
 | Choice | Description |
 |--------|-------------|
 | `None` | No graticule will be displayed. |
-| `Green` (default) | 6 boxes for primary colors, these labels, and skin tone line will be displayed in green. |
+| `Green` | 6 boxes for primary colors, these labels, and skin tone line will be displayed in green. |
+| `Green + IQ` (default) | 6 boxes for primary colors, these labels, and I-Q lines will be displayed in green. |
 
 ### Skin tone color
 


### PR DESCRIPTION
Previously skintone started from the center, which was not easy to find
where is the center. The new graticule is good to find the center.
The start point of the skintone is 0.5 pixel moved to make it same
location as the new I-Q lines.


<!-- If unsure, feel free to let them unchecked. -->
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
