### PR TITLE
dock: Fix crash when starting with Scope Dock

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -56,6 +56,8 @@ bool cm_stagesurface_map(struct cm_source *src, uint8_t **video_data, uint32_t *
 void cm_stagesurface_unmap(struct cm_source *src);
 void cm_render_bypass(struct cm_source *src);
 void cm_tick(void *data, float unused);
+uint32_t cm_get_width(struct cm_source *src);
+uint32_t cm_get_height(struct cm_source *src);
 
 int calc_colorspace(int);
 

--- a/src/histogram.c
+++ b/src/histogram.c
@@ -168,7 +168,7 @@ static uint32_t his_get_width(void *data)
 {
 	struct his_source *src = data;
 	if (src->cm.bypass)
-		return src->cm.known_width;
+		return cm_get_width(&src->cm);
 	if (src->display==DISP_PARADE)
 		return HI_SIZE*n_components(src);
 	return HI_SIZE;
@@ -178,7 +178,7 @@ static uint32_t his_get_height(void *data)
 {
 	struct his_source *src = data;
 	if (src->cm.bypass)
-		return src->cm.known_height;
+		return cm_get_height(&src->cm);
 	if (src->display==DISP_STACK)
 		return src->level_height*n_components(src);
 	return src->level_height;

--- a/src/roi.h
+++ b/src/roi.h
@@ -6,12 +6,22 @@
 extern "C" {
 #endif
 
+struct roi_surface_info_s
+{
+	int x0, y0;
+	int w, h;
+	int surface_height;
+	bool b_rgb, b_yuv;
+};
+
 struct roi_source
 {
 	struct cm_source cm;
 	int n_interleave, i_interleave;
 
 	int x0, x1, y0, y1;
+	struct roi_surface_info_s roi_surface_pos_next;
+	struct roi_surface_info_s roi_surface_pos;
 	int x0sizing, x1sizing, y0sizing, y1sizing;
 	int x0in, x1in, y0in, y1in;
 	uint32_t flags_interact;
@@ -34,16 +44,12 @@ void roi_stagesurfae_unmap(struct roi_source *);
 
 static inline uint32_t roi_width(struct roi_source *src)
 {
-	if (0 <= src->x0 && src->x0 <= src->x1 && src->x1 <= (int)src->cm.known_width)
-		return src->x1 - src->x0;
-	return src->cm.known_width;
+	return src->roi_surface_pos.w;
 }
 
 static inline uint32_t roi_height(struct roi_source *src)
 {
-	if (0 <= src->y0 && src->y0 <= src->y1 && src->y1 <= (int)src->cm.known_height)
-		return src->y1 - src->y0;
-	return src->cm.known_height;
+	return src->roi_surface_pos.h;
 }
 
 #ifdef __cplusplus

--- a/src/scope-widget.cpp
+++ b/src/scope-widget.cpp
@@ -205,7 +205,7 @@ OBSEventFilter *ScopeWidget::BuildEventFilter()
 
 void ScopeWidget::CreateDisplay()
 {
-	if (data->disp)
+	if (data->disp || !windowHandle()->isExposed())
 		return;
 
 	blog(LOG_INFO, "ScopeWidget::CreateDisplay %p", this);

--- a/src/vectorscope.c
+++ b/src/vectorscope.c
@@ -172,13 +172,13 @@ static obs_properties_t *vss_get_properties(void *data)
 static uint32_t vss_get_width(void *data)
 {
 	struct vss_source *src = data;
-	return src->cm.bypass ? src->cm.known_width : VS_SIZE;
+	return src->cm.bypass ? cm_get_width(&src->cm) : VS_SIZE;
 }
 
 static uint32_t vss_get_height(void *data)
 {
 	struct vss_source *src = data;
-	return src->cm.bypass ? src->cm.known_height : VS_SIZE;
+	return src->cm.bypass ? cm_get_height(&src->cm) : VS_SIZE;
 }
 
 static inline void vss_draw_vectorscope(struct vss_source *src, uint8_t *video_data, uint32_t video_line)

--- a/src/waveform.c
+++ b/src/waveform.c
@@ -182,17 +182,17 @@ static uint32_t wvs_get_width(void *data)
 {
 	struct wvs_source *src = data;
 	if (src->cm.bypass)
-		return src->cm.known_width;
+		return cm_get_width(&src->cm);
 	if (src->display==DISP_PARADE)
-		return src->cm.known_width*n_components(src);
-	return src->cm.known_width;
+		return cm_get_width(&src->cm)*n_components(src);
+	return cm_get_width(&src->cm);
 }
 
 static uint32_t wvs_get_height(void *data)
 {
 	struct wvs_source *src = data;
 	if (src->cm.bypass)
-		return src->cm.known_height;
+		return cm_get_height(&src->cm);
 	if (src->display==DISP_STACK)
 		return WV_SIZE*n_components(src);
 	return WV_SIZE;


### PR DESCRIPTION
Just after booting OBS Studio with Scope Dock, a thread `com.apple.main-thread` crashes at `__gl_update_block_invoke` from `libobs-opengl.so`.
Tested OS: macOS 10.11.6 + OBS Studio 26.1.2
Also the same error was reported on macOS 10.15.7.


<!-- If unsure, feel free to let them unchecked. -->
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
  - [x] Crash at the startup is fixed.
  - [x] Crash when switching RGB/YUV on Waveform on the Scope Dock
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.