### PR TITLE
roi: Fix colorspace setting

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -60,6 +60,7 @@ uint32_t cm_get_width(struct cm_source *src);
 uint32_t cm_get_height(struct cm_source *src);
 
 int calc_colorspace(int);
+bool is_roi_source_name(const char *name);
 
 #ifdef __cplusplus
 }

--- a/src/histogram.c
+++ b/src/histogram.c
@@ -117,8 +117,12 @@ static bool components_changed(obs_properties_t *props, obs_property_t *property
 {
 	uint32_t components = settings ? (uint32_t)obs_data_get_int(settings, "components") : 0;
 	obs_property_t *prop = obs_properties_get(props, "colorspace");
+	// TODO: temporarily disable colorspace setting if the target is ROI
+	bool vis = !!(components & COMP_YUV);
+	if (vis && is_roi_source_name(obs_data_get_string(settings, "target_name")))
+		vis = false;
 	if (prop)
-		obs_property_set_visible(prop, !!(components & COMP_YUV));
+		obs_property_set_visible(prop, vis);
 	return true;
 }
 

--- a/src/roi.c
+++ b/src/roi.c
@@ -634,6 +634,16 @@ struct roi_source *roi_from_source(obs_source_t *s)
 	return ret;
 }
 
+bool is_roi_source_name(const char *name)
+{
+	obs_source_t *src = obs_get_source_by_name(name);
+	if (!src)
+		return false;
+	struct roi_source *roi = roi_from_source(src);
+	obs_source_release(src);
+	return !!roi;
+}
+
 struct obs_source_info colormonitor_roi = {
 	.id = "colormonitor_roi",
 	.type = OBS_SOURCE_TYPE_INPUT,

--- a/src/vectorscope.c
+++ b/src/vectorscope.c
@@ -4,6 +4,7 @@
 #include "plugin-macros.generated.h"
 #include "obs-convenience.h"
 #include "common.h"
+#include "roi.h"
 
 #define debug(format, ...)
 
@@ -321,6 +322,9 @@ static void vss_render(void *data, gs_effect_t *effect)
 
 	if (src->update_graticule || src->cm.colorspace<1) {
 		src->cm.colorspace = calc_colorspace(src->colorspace);
+		// TODO: how to set the same colorspace for ROI and all referred sources?
+		if (src->cm.target && src->cm.roi)
+			src->cm.roi->cm.colorspace = src->cm.colorspace;
 		src->update_graticule = 0;
 		gs_vertexbuffer_destroy(src->graticule_vbuf);
 		src->graticule_vbuf = NULL;

--- a/src/waveform.c
+++ b/src/waveform.c
@@ -125,8 +125,12 @@ static bool components_changed(obs_properties_t *props, obs_property_t *property
 {
 	uint32_t components = settings ? (uint32_t)obs_data_get_int(settings, "components") : 0;
 	obs_property_t *prop = obs_properties_get(props, "colorspace");
+	// TODO: temporarily disable colorspace setting if the target is ROI
+	bool vis = !!(components & COMP_YUV);
+	if (vis && is_roi_source_name(obs_data_get_string(settings, "target_name")))
+		vis = false;
 	if (prop)
-		obs_property_set_visible(prop, !!(components & COMP_YUV));
+		obs_property_set_visible(prop, vis);
 	return true;
 }
 


### PR DESCRIPTION
Temporarily set colorspace of ROI from vectorscope.
The colorspace property in other sources are disabled if the target is ROI.


<!-- If unsure, feel free to let them unchecked. -->
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.

Fix #26.