### PR TITLE
dock: Fix scene-collection change to remove old docks

### DIFF
--- a/src/scope-dock.hpp
+++ b/src/scope-dock.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <QDockWidget>
+#include <QPointer>
+#include <QAction>
 #include <string>
 
 class ScopeDock : public QDockWidget {
@@ -9,6 +11,7 @@ class ScopeDock : public QDockWidget {
 public:
 	class ScopeWidget *widget;
 	std::string name;
+	QPointer<QAction> action = 0;
 
 public:
 	ScopeDock(QWidget *parent = nullptr);


### PR DESCRIPTION
When switching scene-collection, old dock instances are not removed. It causes the number of dock instances to increase exponentially.


<!-- If unsure, feel free to let them unchecked. -->
- [ ] The commit is reviewed by yourself.
- [x] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [ ] The commit is compatible with repository's license.