### PR TITLE
dock: Revise open and close of docks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ set(PLUGIN_SOURCES
 	src/common-cpp.cc
 	src/obs-convenience.c
 	src/scope-dock.cpp
+	src/scope-dock-new-dialog.cpp
 	src/scope-widget.cpp
 	src/scope-widget-properties.cpp
 	src-obsstudio/properties-view.cpp
@@ -80,6 +81,7 @@ set(PLUGIN_HEADERS
 	src/common.h
 	src/obs-convenience.h
 	src/scope-dock.hpp
+	src/scope-dock-new-dialog.hpp
 	src/scope-widget.hpp
 	src/obsgui-helper.hpp
 	src/scope-widget-properties.hpp

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ In addition, a dock widget is available.
 
 ### Dock
 1. Install the plugin and boot OBS Studio.
-1. Click `View`, `Dock`, and `Scope: program` in menu. you will see a new dock containing vectorscope, waveform, and histogram for the program.
+1. Click `Tools` and `New Scope Dock...` in the menu of OBS Studio.
+1. Input the name, optionally set the source to monitor, and clock OK. You will see a new dock containing vectorscope, waveform, and histogram for the program.
 
 ### Projector View
 1. Install the plugin and boot OBS Studio.

--- a/doc/dock.md
+++ b/doc/dock.md
@@ -7,7 +7,8 @@ Color Scope Dock shows vectorscope, waveform, histogram and ROI (region of inter
 ## Opening the Color Scope Dock
 
 To open the dock,
-Click `View`, `Docks`, and `Scope: program` in the menu of OBS Studio.
+Click `Tools` and `New Scope Dock...` in the menu of OBS Studio.
+Input the name and clock OK.
 
 ## ROI Mouse Interaction
 

--- a/src/scope-dock-new-dialog.cpp
+++ b/src/scope-dock-new-dialog.cpp
@@ -1,0 +1,68 @@
+#include <obs-module.h>
+#include <QMainWindow>
+#include <QGridLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QComboBox>
+#include <QRadioButton>
+#include <QDialogButtonBox>
+#include "plugin-macros.generated.h"
+#include "scope-dock.hpp"
+#include "scope-dock-new-dialog.hpp"
+#include "scope-widget.hpp"
+
+ScopeDockNewDialog::ScopeDockNewDialog(QMainWindow *parent)
+	: QDialog(parent)
+{
+	QLabel *label;
+	int ix = 0;
+	mainLayout = new QGridLayout;
+
+	label = new QLabel(obs_module_text("Dock Title"));
+	editTitle = new QLineEdit();
+	mainLayout->addWidget(label, ix, 0, Qt::AlignRight);
+	mainLayout->addWidget(editTitle, ix++, 1, Qt::AlignCenter);
+
+	label = new QLabel(obs_module_text("Source"));
+	radioProgram = new QRadioButton(obs_module_text("Program"));
+	radioProgram->setChecked(true);
+	radioPreview = new QRadioButton(obs_module_text("Preview"));
+	mainLayout->addWidget(label, ix, 0, 3, 1, Qt::AlignRight);
+	mainLayout->addWidget(radioProgram, ix++, 1, Qt::AlignLeft);
+	mainLayout->addWidget(radioPreview, ix++, 1, Qt::AlignLeft);
+	mainLayout->addWidget(new QLabel(obs_module_text("Other sources can be selected after creation")), ix++, 1, Qt::AlignLeft);
+	// TODO: other sources
+
+	QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+	mainLayout->addWidget(buttonBox, ix++, 1, Qt::AlignRight);
+	connect(buttonBox, SIGNAL(accepted()), this, SLOT(accept()));
+	connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
+
+	setLayout(mainLayout);
+}
+
+ScopeDockNewDialog::~ScopeDockNewDialog()
+{
+}
+
+void ScopeDockNewDialog::accept()
+{
+	const char *name = editTitle->text().toStdString().c_str();
+	const char *srcName = NULL;
+	obs_data_t *props = obs_data_create();
+	obs_data_t *roi_prop = obs_data_create();
+	if (radioPreview->isChecked())
+		srcName = "\x10"; // preview
+
+	if (srcName)
+		obs_data_set_string(roi_prop, "target_name", srcName);
+	obs_data_set_obj(props, "colormonitor_roi-prop", roi_prop);
+	ScopeWidget::default_properties(props);
+
+	scope_dock_add(name, props);
+
+	obs_data_release(roi_prop);
+	obs_data_release(props);
+
+	QDialog::accept();
+}

--- a/src/scope-dock-new-dialog.hpp
+++ b/src/scope-dock-new-dialog.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <obs.h>
+#include <QDialog>
+
+class ScopeDockNewDialog : public QDialog
+{
+	Q_OBJECT
+	class QGridLayout *mainLayout;
+	class QLineEdit *editTitle;
+	class QRadioButton *radioProgram;
+	class QRadioButton *radioPreview;
+	// class QRadioButton *radioSource;
+	// class QComboBox *editSourceName;
+
+public:
+	ScopeDockNewDialog(class QMainWindow *parent = NULL);
+	~ScopeDockNewDialog();
+
+public slots:
+	void accept() override;
+};

--- a/src/scope-dock.cpp
+++ b/src/scope-dock.cpp
@@ -42,6 +42,7 @@ static void scope_dock_add(const char *name, obs_data_t *props)
 ScopeDock::ScopeDock(QWidget *parent)
 	: QDockWidget(parent)
 {
+	setAttribute(Qt::WA_DeleteOnClose);
 }
 
 ScopeDock::~ScopeDock()

--- a/src/scope-dock.hpp
+++ b/src/scope-dock.hpp
@@ -25,5 +25,6 @@ private:
 	void hideEvent(QHideEvent *event) override;
 };
 
+extern "C" void scope_dock_add(const char *name, obs_data_t *props);
 extern "C" void scope_docks_init();
 extern "C" void scope_docks_release();


### PR DESCRIPTION
The flow to open and close the dock is revised.

- When a user closed the dock widget, the instance will be deleted, where previously it was just hidden.
- Due to above change, the user cannot find the lagacy way (`View` -> `Docks` -> `Scope: program`) to open the dock once the user closed the dock.
- When opening the dock, user can navigate `Tools` and `New Scope Dock...` from the menu and user can create any number of docks.
- In addition, user can select target source of the scope dock.

<!-- If unsure, feel free to let them unchecked. -->
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
