### PR TITLE
roi: Fix not updated stage-surface information

### DIFF
--- a/src/roi.c
+++ b/src/roi.c
@@ -279,6 +279,10 @@ static void roi_stage_texture(struct roi_source *src)
 		PROFILE_START(prof_stage_surface_name);
 		gs_stage_texture(src->cm.stagesurface, gs_texrender_get_texture(src->cm.texrender));
 		PROFILE_END(prof_stage_surface_name);
+		set_roi_info(&src->roi_surface_pos_next, src);
+		src->roi_surface_pos_next.surface_height = height;
+		src->roi_surface_pos_next.b_rgb = src->b_rgb;
+		src->roi_surface_pos_next.b_yuv = src->b_yuv;
 		return;
 	}
 


### PR DESCRIPTION
When YUV is not selected, metadata for stage-surface is not updated, which causes these problems on waveform and histogram.
- When YUV is not selected from the startup, nothing is displayed.
- When the component type is switched or vectorscope is disabled during
  runtime, waveform and histogram stop following the ROI selection.

This PR also fixes issue #39.

<!-- If unsure, feel free to let them unchecked. -->
- [ ] The commit is reviewed by yourself.
- [ ] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [ ] The commit is compatible with repository's license.
