### PR TITLE
dock: Fix titile cannot be set on Windows

### DIFF
--- a/src/scope-dock-new-dialog.cpp
+++ b/src/scope-dock-new-dialog.cpp
@@ -48,7 +48,6 @@ ScopeDockNewDialog::~ScopeDockNewDialog()
 
 void ScopeDockNewDialog::accept()
 {
-	const char *name = editTitle->text().toStdString().c_str();
 	const char *srcName = NULL;
 	obs_data_t *props = obs_data_create();
 	obs_data_t *roi_prop = obs_data_create();
@@ -60,7 +59,7 @@ void ScopeDockNewDialog::accept()
 	obs_data_set_obj(props, "colormonitor_roi-prop", roi_prop);
 	ScopeWidget::default_properties(props);
 
-	scope_dock_add(name, props);
+	scope_dock_add(editTitle->text().toUtf8().constData(), props);
 
 	obs_data_release(roi_prop);
 	obs_data_release(props);

--- a/src/scope-dock.cpp
+++ b/src/scope-dock.cpp
@@ -22,7 +22,7 @@ void scope_dock_add(const char *name, obs_data_t *props)
 	auto *main_window = static_cast<QMainWindow *>(obs_frontend_get_main_window());
 	auto *dock = new ScopeDock(main_window);
 	dock->name = name;
-	dock->setObjectName(QString(name) + OBJ_NAME_SUFFIX);
+	dock->setObjectName(QString::fromUtf8(name) + OBJ_NAME_SUFFIX);
 	dock->setWindowTitle(name);
 	dock->resize(256, 256);
 	dock->setMinimumSize(128, 128);


### PR DESCRIPTION
There was an incorrect conversion from QString to UTF-8.

The bug was reported on the forum: https://obsproject.com/forum/threads/obs-color-monitor.143375/post-538366

<!-- If unsure, feel free to let them unchecked. -->
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
