### PR TITLE
vectorscope: Accept mouse wheel to zoom

### DIFF
--- a/data/vectorscope.effect
+++ b/data/vectorscope.effect
@@ -45,7 +45,7 @@ float4 PSConvertRGB_UV601(VertInOut vert_in) : TARGET
 {
 	float4 rgb = image.Sample(cnv_sampler, vert_in.uv);
 	float4 uv00;
-	uv00.z = -0.147643 * rgb.x -0.289855 * rgb.y +0.437500 * rgb.z +0.5; // U
+	uv00.z = -0.147643 * rgb.x -0.289855 * rgb.y +0.437500 * rgb.z +0.5 - 1.0/256.0; // U
 	uv00.y = +0.299000 * rgb.x +0.587000 * rgb.y +0.114000 * rgb.z; // TODO: separate to *_YUV*
 	uv00.x = +0.437500 * rgb.x -0.366351 * rgb.y -0.071147 * rgb.z +0.5; // V
 	uv00.a = 1;
@@ -56,7 +56,7 @@ float4 PSConvertRGB_UV709(VertInOut vert_in) : TARGET
 {
 	float4 rgb = image.Sample(cnv_sampler, vert_in.uv);
 	float4 uv00;
-	uv00.z = -0.100643 * rgb.x -0.338571 * rgb.y +0.439216 * rgb.z +0.5; // U
+	uv00.z = -0.100643 * rgb.x -0.338571 * rgb.y +0.439216 * rgb.z +0.5 - 1.0/256.0; // U
 	uv00.y = +0.212600 * rgb.x +0.715200 * rgb.y +0.072200 * rgb.z; // TODO: separate to *_YUV*
 	uv00.x = +0.439216 * rgb.x -0.398941 * rgb.y -0.040273 * rgb.z +0.5; // V
 	uv00.a = 1;


### PR DESCRIPTION
User can zoom-in and -out by rotating mouse wheel.
The center of the black point is adjusted so that the zoom is centered by the black point.

<!-- If unsure, feel free to let them unchecked. -->
- [ ] The commit is reviewed by yourself.
- [x] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
