### PR TITLE
Move global effect pointer to each instance

### DIFF
--- a/data/common.effect
+++ b/data/common.effect
@@ -1,0 +1,61 @@
+uniform float4x4 ViewProj;
+uniform texture2d image;
+
+sampler_state cnv_sampler {
+	Filter   = Point;
+	AddressU = Clamp;
+	AddressV = Clamp;
+};
+
+struct VertInOut {
+	float4 pos : POSITION;
+	float2 uv  : TEXCOORD0;
+};
+
+VertInOut VSDefault(VertInOut vert_in)
+{
+	VertInOut vert_out;
+	vert_out.pos = mul(float4(vert_in.pos.xyz, 1.0), ViewProj);
+	vert_out.uv  = vert_in.uv;
+	return vert_out;
+}
+
+float4 PSConvertRGB_YUV601(VertInOut vert_in) : TARGET
+{
+	float4 rgb = image.Sample(cnv_sampler, vert_in.uv);
+	float4 uv00;
+	uv00.z = -0.147643 * rgb.x -0.289855 * rgb.y +0.437500 * rgb.z +0.5 - 1.0/256.0; // U
+	uv00.y = +0.299000 * rgb.x +0.587000 * rgb.y +0.114000 * rgb.z; // Y
+	uv00.x = +0.437500 * rgb.x -0.366351 * rgb.y -0.071147 * rgb.z +0.5; // V
+	uv00.a = 1;
+	return uv00;
+}
+
+float4 PSConvertRGB_YUV709(VertInOut vert_in) : TARGET
+{
+	float4 rgb = image.Sample(cnv_sampler, vert_in.uv);
+	float4 uv00;
+	uv00.z = -0.100643 * rgb.x -0.338571 * rgb.y +0.439216 * rgb.z +0.5 - 1.0/256.0; // U
+	uv00.y = +0.212600 * rgb.x +0.715200 * rgb.y +0.072200 * rgb.z; // Y
+	uv00.x = +0.439216 * rgb.x -0.398941 * rgb.y -0.040273 * rgb.z +0.5; // V
+	uv00.a = 1;
+	return uv00;
+}
+
+technique ConvertRGB_YUV601
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSConvertRGB_YUV601(vert_in);
+	}
+}
+
+technique ConvertRGB_YUV709
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSConvertRGB_YUV709(vert_in);
+	}
+}

--- a/data/vectorscope.effect
+++ b/data/vectorscope.effect
@@ -9,12 +9,6 @@ sampler_state def_sampler {
 	AddressV = Clamp;
 };
 
-sampler_state cnv_sampler {
-	Filter   = Point;
-	AddressU = Clamp;
-	AddressV = Clamp;
-};
-
 struct VertInOut {
 	float4 pos : POSITION;
 	float2 uv  : TEXCOORD0;
@@ -41,28 +35,6 @@ float4 PSDrawGraticule(VertInOut vert_in) : TARGET
 	return float4(color.xyz, color.a*a);
 }
 
-float4 PSConvertRGB_UV601(VertInOut vert_in) : TARGET
-{
-	float4 rgb = image.Sample(cnv_sampler, vert_in.uv);
-	float4 uv00;
-	uv00.z = -0.147643 * rgb.x -0.289855 * rgb.y +0.437500 * rgb.z +0.5 - 1.0/256.0; // U
-	uv00.y = +0.299000 * rgb.x +0.587000 * rgb.y +0.114000 * rgb.z; // TODO: separate to *_YUV*
-	uv00.x = +0.437500 * rgb.x -0.366351 * rgb.y -0.071147 * rgb.z +0.5; // V
-	uv00.a = 1;
-	return uv00;
-}
-
-float4 PSConvertRGB_UV709(VertInOut vert_in) : TARGET
-{
-	float4 rgb = image.Sample(cnv_sampler, vert_in.uv);
-	float4 uv00;
-	uv00.z = -0.100643 * rgb.x -0.338571 * rgb.y +0.439216 * rgb.z +0.5 - 1.0/256.0; // U
-	uv00.y = +0.212600 * rgb.x +0.715200 * rgb.y +0.072200 * rgb.z; // TODO: separate to *_YUV*
-	uv00.x = +0.439216 * rgb.x -0.398941 * rgb.y -0.040273 * rgb.z +0.5; // V
-	uv00.a = 1;
-	return uv00;
-}
-
 technique Draw
 {
 	pass
@@ -78,23 +50,5 @@ technique DrawGraticule
 	{
 		vertex_shader = VSDefault(vert_in);
 		pixel_shader  = PSDrawGraticule(vert_in);
-	}
-}
-
-technique ConvertRGB_UV601
-{
-	pass
-	{
-		vertex_shader = VSDefault(vert_in);
-		pixel_shader  = PSConvertRGB_UV601(vert_in);
-	}
-}
-
-technique ConvertRGB_UV709
-{
-	pass
-	{
-		vertex_shader = VSDefault(vert_in);
-		pixel_shader  = PSConvertRGB_UV709(vert_in);
 	}
 }

--- a/src/common.h
+++ b/src/common.h
@@ -20,6 +20,7 @@ struct cm_source
 	gs_texrender_t *texrender;
 	gs_texrender_t *texrender_yuv;
 	gs_stagesurf_t* stagesurface;
+	gs_effect_t *effect;
 	uint32_t known_width;
 	uint32_t known_height;
 	bool rendered;
@@ -67,6 +68,8 @@ static inline bool cm_is_roi(const struct cm_source *src)
 
 int calc_colorspace(int);
 bool is_roi_source_name(const char *name);
+
+gs_effect_t *create_effect_from_module_file(const char *basename);
 
 #ifdef __cplusplus
 }

--- a/src/plugin-main.c
+++ b/src/plugin-main.c
@@ -31,9 +31,6 @@ extern struct obs_source_info colormonitor_zebra_filter;
 extern struct obs_source_info colormonitor_falsecolor;
 extern struct obs_source_info colormonitor_falsecolor_filter;
 extern struct obs_source_info colormonitor_roi;
-extern gs_effect_t *cm_rgb2yuv_effect;
-extern gs_effect_t *wvs_effect;
-extern gs_effect_t *his_effect;
 void scope_docks_init();
 void scope_docks_release();
 
@@ -54,18 +51,6 @@ bool obs_module_load(void)
 
 void obs_module_unload()
 {
-	if (cm_rgb2yuv_effect) {
-		gs_effect_destroy(cm_rgb2yuv_effect);
-		cm_rgb2yuv_effect = NULL;
-	}
-	if (wvs_effect) {
-		gs_effect_destroy(wvs_effect);
-		wvs_effect = NULL;
-	}
-	if (his_effect) {
-		gs_effect_destroy(his_effect);
-		his_effect = NULL;
-	}
 	scope_docks_release();
 	blog(LOG_INFO, "plugin unloaded");
 }

--- a/src/roi.c
+++ b/src/roi.c
@@ -34,8 +34,6 @@ static const char *prof_stage_surface_name = "stage_surface";
 #define INTERACT_HANDLE_TI 0x200
 #define INTERACT_HANDLE_BI 0x800
 
-extern gs_effect_t *cm_rgb2yuv_effect;
-
 static const char *roi_get_name(void *unused)
 {
 	UNUSED_PARAMETER(unused);
@@ -310,10 +308,10 @@ static void roi_stage_texture(struct roi_source *src)
 	}
 
 	gs_texture_t *tex = gs_texrender_get_texture(src->cm.texrender);
-	if (cm_rgb2yuv_effect && tex) {
+	if (src->cm.effect && tex) {
 		PROFILE_START(prof_convert_yuv_name);
-		gs_effect_set_texture(gs_effect_get_param_by_name(cm_rgb2yuv_effect, "image"), tex);
-		while (gs_effect_loop(cm_rgb2yuv_effect, src->cm.colorspace==1 ? "ConvertRGB_UV601" : "ConvertRGB_UV709"))
+		gs_effect_set_texture(gs_effect_get_param_by_name(src->cm.effect, "image"), tex);
+		while (gs_effect_loop(src->cm.effect, src->cm.colorspace==1 ? "ConvertRGB_YUV601" : "ConvertRGB_YUV709"))
 			gs_draw_sprite(tex, 0, width, height0);
 		PROFILE_END(prof_convert_yuv_name);
 	}


### PR DESCRIPTION
Since the effects are cached in libobs, it is not necessary to have the global variables to hold the pointer to the effect file. All the global effect pointers are moved into the structures of the instances. Also separated RGB to YUV conversion effect to common.effect.


<!-- If unsure, feel free to let them unchecked. -->
- [ ] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
