### PR TITLE
cmake: Use Qt:: instead of Qt5:: and remove unnecessary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,20 +101,14 @@ add_library(${CMAKE_PROJECT_NAME} MODULE ${PLUGIN_SOURCES} ${PLUGIN_HEADERS})
 
 include_directories(
 	"${LIBOBS_INCLUDE_DIR}/../UI/obs-frontend-api"
-	${LIBOBS_INCLUDE_DIR}
 	src-obsstudio/
-	${Qt5Core_INCLUDES}
-	${Qt5Widgets_INCLUDES}
-	${Qt5Gui_INCLUDES}
-	${Qt5Gui_PRIVATE_INCLUDE_DIRS}
 )
 
 target_link_libraries(${CMAKE_PROJECT_NAME}
 	libobs
-	Qt5::Core
-	Qt5::Widgets
-	Qt5::Gui
-	Qt5::GuiPrivate
+	Qt::Widgets
+	Qt::Gui
+	Qt::GuiPrivate
 )
 
 # --- End of section ---


### PR DESCRIPTION
To prepare future Qt6 support, use `Qt::` instead of `Qt5::`.
Also removes unnecessary entries on `include_directories` since these include directories are set by `target_link_libraries`.

This change is inspired by obsproject/obs-studio#6782.

<!-- If unsure, feel free to let them unchecked. -->
- [ ] The commit is reviewed by yourself.
- [ ] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
