### PR TITLE
CI(macOS): generate universal binary package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -201,7 +201,7 @@ jobs:
               cp LICENSE release/${PLUGIN_NAME}/data/LICENSE-$PLUGIN_NAME
               ;;
             28)
-              (cd release/${PLUGIN_NAME}.plugin/Contents && ../../../ci/macos/change-rpath.sh -obs 28 -lib lib/ bin/${PLUGIN_NAME})
+              (cd release/${PLUGIN_NAME}.plugin/Contents && ../../../ci/macos/change-rpath.sh -obs 28 -lib lib/ MacOS/${PLUGIN_NAME})
               cp LICENSE release/${PLUGIN_NAME}.plugin/Contents/Resources/LICENSE-$PLUGIN_NAME
               ;;
           esac
@@ -210,18 +210,26 @@ jobs:
         if: ${{ github.event_name != 'pull_request' && steps.setup.outputs.haveCodesignIdent == 'true' }}
         run: |
           . ci/ci_includes.generated.sh
-          set -ex
-          files=($(ls release/${PLUGIN_NAME}/*/*.dylib || :))
+          set -e
           case ${{ matrix.obs }} in
             27)
-              files=(release/${PLUGIN_NAME}/bin/${PLUGIN_NAME}.so "${files[@]}")
+              files=(
+                $(find release/${PLUGIN_NAME}/ -name '*.dylib')
+                release/${PLUGIN_NAME}/bin/${PLUGIN_NAME}.so
+              )
               ;;
             28)
-              files=(release/${PLUGIN_NAME}.plugin/Contents/MacOS/${PLUGIN_NAME} "${files[@]}")
+              files=(
+                $(find release/${PLUGIN_NAME}.plugin/ -name '*.dylib')
+                release/${PLUGIN_NAME}.plugin/Contents/MacOS/${PLUGIN_NAME}
+              )
               ;;
           esac
           for dylib in "${files[@]}"; do
-            codesign --sign "${{ secrets.MACOS_SIGNING_APPLICATION_IDENTITY }}" "$dylib"
+            codesign --force --sign "${{ secrets.MACOS_SIGNING_APPLICATION_IDENTITY }}" "$dylib"
+          done
+          for dylib in "${files[@]}"; do
+            codesign -vvv --deep --strict "$dylib"
           done
 
       - name: Package

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,8 +97,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        obs: [27, 28]
-        arch: [x86_64, arm64]
+        include:
+          - obs: 27
+            arch: x86_64
+          - obs: 28
+            arch: universal
     defaults:
       run:
         shell: bash
@@ -179,7 +182,7 @@ jobs:
             -D QT_VERSION=$OBS_QT_VERSION_MAJOR \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_PREFIX_PATH="$PWD/release/" \
-            -DCMAKE_OSX_ARCHITECTURES=$arch \
+            -DCMAKE_OSX_ARCHITECTURES=${arch/#universal/x86_64;arm64} \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} \
             -DCMAKE_FRAMEWORK_PATH="$deps/Frameworks;$deps/lib/cmake;$deps" \
             -D PKG_SUFFIX=$PKG_SUFFIX \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,7 +140,7 @@ jobs:
           p12-password: ${{ secrets.MACOS_SIGNING_CERT_PASSWORD }}
 
       - name: Set Signing Identity
-        if: ${{ github.event_name != 'pull_request' && steps.setup.outputs.haveCodesignIdent == 'true' }}
+        if: ${{ startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request' && steps.setup.outputs.haveCodesignIdent == 'true' }}
         run: |
           set -e
           TEAM_ID=$(echo "${{ secrets.MACOS_SIGNING_APPLICATION_IDENTITY }}" | sed 's/.*(\([A-Za-z0-9]*\))$/\1/')


### PR DESCRIPTION

### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

- Build universal binary instead of arm64 for OBS 28
- Update packaging and codesign script
- Do not register signing identity for main branch CI

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [ ] The commit is reviewed by yourself.
- [ ] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [ ] The commit is compatible with repository's license.
