### PR TITLE
.github: Improve RPM package build flow for Fedora

### DIFF
--- a/.github/containers/fedora-common/build.sh
+++ b/.github/containers/fedora-common/build.sh
@@ -6,6 +6,7 @@ docker_image="$1"
 rpmbuild="$2"
 
 PLUGIN_NAME=$(awk '/^project\(/{print gensub(/project\(([^ ()]*).*/, "\\1", 1, $0)}' CMakeLists.txt)
+OBS_VERSION=$(docker run $docker_image bash -c 'rpm -q --qf "%{version}" obs-studio')
 eval $(git describe --tag --always --long | awk '
 BEGIN {
 	VERSION="unknown";
@@ -34,6 +35,7 @@ sed \
 	-e "s/@PLUGIN_NAME@/$PLUGIN_NAME/g" \
 	-e "s/@VERSION@/$VERSION/g" \
 	-e "s/@RELEASE@/$RELEASE/g" \
+	-e "s/@OBS_VERSION@/$OBS_VERSION/g" \
 	< ci/plugin.spec \
 	> $rpmbuild/SPECS/$PLUGIN_NAME.spec
 

--- a/.github/containers/fedora36/Dockerfile
+++ b/.github/containers/fedora36/Dockerfile
@@ -5,6 +5,7 @@ RUN dnf install -y rpm-build python3-dnf-plugins-core && dnf clean all
 # https://docs.fedoraproject.org/en-US/quick-docs/setup_rpmfusion/
 RUN dnf install -y https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm && dnf clean all
 RUN dnf install -y obs-studio obs-studio-devel && dnf clean all
+RUN dnf install -y qt5-qtbase-devel qt5-qtbase-private-devel && dnf clean all
 
 RUN useradd -s /bin/bash -m rpm
 RUN echo >> /etc/sudoers

--- a/.github/containers/fedora37/Dockerfile
+++ b/.github/containers/fedora37/Dockerfile
@@ -5,6 +5,7 @@ RUN dnf install -y rpm-build python3-dnf-plugins-core && dnf clean all
 # https://docs.fedoraproject.org/en-US/quick-docs/setup_rpmfusion/
 RUN dnf install -y https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm && dnf clean all
 RUN dnf install -y obs-studio obs-studio-devel && dnf clean all
+RUN dnf install -y qt5-qtbase-devel qt5-qtbase-private-devel && dnf clean all
 
 RUN useradd -s /bin/bash -m rpm
 RUN echo >> /etc/sudoers

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
+          fetch-depth: 0
           submodules: recursive
 
       - name: Restore docker from cache

--- a/ci/plugin.spec
+++ b/ci/plugin.spec
@@ -5,6 +5,7 @@ Summary: Color monitor plugin for OBS Studio
 License: GPLv2+
 
 Source0: %{name}-%{version}.tar.bz2
+Requires: obs-studio >= @OBS_VERSION@
 BuildRequires: cmake, gcc, gcc-c++
 BuildRequires: obs-studio-devel
 BuildRequires: qt5-qtbase-devel qt5-qtbase-private-devel

--- a/ci/plugin.spec
+++ b/ci/plugin.spec
@@ -1,6 +1,6 @@
 Name: @PLUGIN_NAME@
 Version: @VERSION@
-Release: 1%{?dist}
+Release: @RELEASE@%{?dist}
 Summary: Color monitor plugin for OBS Studio
 License: GPLv2+
 


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->
This PR improves the build flow for RPM packages.

- Install Qt5 libraries to docker so that the action will be faster if the docker is cached.
- Set obs-studio required version is greater than or equal to the current obs-studio version.
- Release number in the spec file will be automatically set.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
