### PR TITLE
.github: Use a different cmake generator

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -279,7 +279,7 @@ jobs:
         obs: [27, 28]
         arch: [x64]
     env:
-      visualStudio: 'NMake Makefiles'
+      visualStudio: 'Ninja Multi-Config'
       Configuration: 'RelWithDebInfo'
     defaults:
       run:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -279,6 +279,7 @@ jobs:
         obs: [27, 28]
         arch: [x64]
     env:
+      visualStudio: 'NMake Makefiles'
       Configuration: 'RelWithDebInfo'
     defaults:
       run:
@@ -297,6 +298,7 @@ jobs:
         run: |
           cmake -G
           $CmakeArgs = @(
+            '-G', "${{ env.visualStudio }}"
             '-DQT_VERSION=${{ steps.obsdeps.outputs.OBS_QT_VERSION_MAJOR }}'
             '-DCMAKE_SYSTEM_VERSION=10.0.18363.657'
             "-DCMAKE_INSTALL_PREFIX=$(Resolve-Path -Path "./obs-build-dependencies/plugin-deps-${{ matrix.arch }}")"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -279,7 +279,6 @@ jobs:
         obs: [27, 28]
         arch: [x64]
     env:
-      visualStudio: 'Visual Studio 17 2022'
       Configuration: 'RelWithDebInfo'
     defaults:
       run:
@@ -297,7 +296,6 @@ jobs:
       - name: Build plugin
         run: |
           $CmakeArgs = @(
-            '-G', "${{ env.visualStudio }}"
             '-DQT_VERSION=${{ steps.obsdeps.outputs.OBS_QT_VERSION_MAJOR }}'
             '-DCMAKE_SYSTEM_VERSION=10.0.18363.657'
             "-DCMAKE_INSTALL_PREFIX=$(Resolve-Path -Path "./obs-build-dependencies/plugin-deps-${{ matrix.arch }}")"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -295,6 +295,7 @@ jobs:
           obs: ${{ matrix.obs }}
       - name: Build plugin
         run: |
+          cmake -G
           $CmakeArgs = @(
             '-DQT_VERSION=${{ steps.obsdeps.outputs.OBS_QT_VERSION_MAJOR }}'
             '-DCMAKE_SYSTEM_VERSION=10.0.18363.657'


### PR DESCRIPTION

### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

The `-G` option is removed from the cmake command line on Windows.

In current CI, it took 40 seconds to switch Visual Studio version, which I want to eliminate.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [ ] The commit is reviewed by yourself.
- [ ] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [ ] The commit is compatible with repository's license.
