### PR TITLE
roi: Fix crash when creating an ROI source

### DIFF
--- a/src/roi.c
+++ b/src/roi.c
@@ -50,6 +50,8 @@ static void *roi_create(obs_data_t *settings, obs_source_t *source)
 {
 	struct roi_source *src = bzalloc(sizeof(struct roi_source));
 
+	pthread_mutex_init(&src->sources_mutex, NULL);
+
 	src->cm.flags = ROI_DEFAULT_CM_FLAG;
 	cm_create(&src->cm, settings, source);
 	cm_request(&src->cm, roi_surface_cb, src);
@@ -76,6 +78,7 @@ static void roi_destroy(void *data)
 
 	cm_destroy(&src->cm);
 	da_free(src->sources);
+	pthread_mutex_destroy(&src->sources_mutex);
 
 	bfree(src);
 }


### PR DESCRIPTION

### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

Initialize a mutex, which was missing.

The bug was introduced at 4e68dc7b70 "Implement pipeline to render". A crash was reported on Windows.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

Not tested yet.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [ ] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
