### PR TITLE
dock: Add a surface event filter to destroy display context

### DIFF
--- a/src-obsstudio/properties-view.cpp
+++ b/src-obsstudio/properties-view.cpp
@@ -866,6 +866,9 @@ void DockProp_WidgetInfo::ListChanged(const char *setting)
 		obs_data_set_string(view->settings, setting,
 				    data.toByteArray().constData());
 		break;
+	default:
+		blog(LOG_ERROR, "%s: Unimplemented format %d", __FUNCTION__,
+		     (int)format);
 	}
 }
 

--- a/src/SurfaceEventFilter.hpp
+++ b/src/SurfaceEventFilter.hpp
@@ -1,0 +1,34 @@
+#pragma once
+#include <QObject>
+
+template<typename QTDisplay_class> class SurfaceEventFilter : public QObject {
+	QTDisplay_class *w;
+
+public:
+	SurfaceEventFilter(QTDisplay_class *w_) : w(w_) {}
+
+protected:
+	bool eventFilter(QObject *obj, QEvent *event) override
+	{
+		bool result = QObject::eventFilter(obj, event);
+		QPlatformSurfaceEvent *surfaceEvent;
+
+		switch (event->type()) {
+		case QEvent::PlatformSurface:
+			surfaceEvent = static_cast<QPlatformSurfaceEvent *>(event);
+
+			switch (surfaceEvent->surfaceEventType()) {
+			case QPlatformSurfaceEvent::SurfaceAboutToBeDestroyed:
+				w->DestroyDisplay();
+				break;
+			default:
+				break;
+			}
+			break;
+		default:
+			break;
+		}
+
+		return result;
+	}
+};

--- a/src/scope-widget.hpp
+++ b/src/scope-widget.hpp
@@ -7,6 +7,7 @@
 #define SCOPE_WIDGET_N_SRC 6
 
 class OBSEventFilter;
+template<typename QTDisplay_class> class SurfaceEventFilter;
 
 class ScopeWidget : public QWidget {
 	Q_OBJECT
@@ -14,8 +15,8 @@ class ScopeWidget : public QWidget {
 	struct scope_widget_s *data;
 	class ScopeWidgetProperties *properties;
 	std::unique_ptr<OBSEventFilter> eventFilter;
+	std::unique_ptr<SurfaceEventFilter<ScopeWidget>> surfaceEventFilter;
 
-	void CreateDisplay();
 	void resizeEvent(QResizeEvent *event) override;
 	void paintEvent(QPaintEvent *event) override;
 	class QPaintEngine *paintEngine() const override;
@@ -35,6 +36,8 @@ public slots:
 public:
 	ScopeWidget(QWidget *parent);
 	~ScopeWidget();
+	void CreateDisplay();
+	void DestroyDisplay();
 	static void default_properties(obs_data_t *);
 	void save_properties(obs_data_t *);
 	void load_properties(obs_data_t *);


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

When the dock is floating, `SurfaceAboutToBeDestroyed` event arrives earlier than `~ScopeWidget()`. Let's destroy the display context at the event.

On the other hand, if it's docked, `~ScopeWidget()` arrives earlier than `SurfaceAboutToBeDestroyed`. I need to remove the event filter not to access the released object from the surface event filter.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [ ] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
