### PR TITLE
Drop supporting OBS 29 and earlier

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        obs: [27, 28]
-        ubuntu: ['ubuntu-20.04', 'ubuntu-22.04']
+        obs: [30]
+        ubuntu: ['ubuntu-22.04']
     defaults:
       run:
         shell: bash
@@ -36,7 +36,7 @@ jobs:
 
       - name: Download obs-studio development environment
         id: obsdeps
-        uses: norihiro/obs-studio-devel-action@v1-beta
+        uses: norihiro/obs-studio-devel-action@v2
         with:
           obs: ${{ matrix.obs }}
           verbose: true
@@ -44,30 +44,12 @@ jobs:
       - name: Build plugin
         run: |
           set -ex
-          OBS_QT_VERSION_MAJOR=${{ steps.obsdeps.outputs.OBS_QT_VERSION_MAJOR }}
-          mkdir build
-          cd build
-          case ${{ matrix.obs }} in
-            27)
-              cmake_opt=(
-                -D CMAKE_INSTALL_LIBDIR=/usr/lib/
-                -D CPACK_DEBIAN_PACKAGE_DEPENDS='obs-studio (>= 27), obs-studio (<< 28)'
-              )
-              ;;
-            28)
-              cmake_opt=(
-                -D CPACK_DEBIAN_PACKAGE_DEPENDS='obs-studio (>= 28)'
-              )
-              ;;
-          esac
-          cmake .. \
-            -D QT_VERSION=$OBS_QT_VERSION_MAJOR \
-            -D CMAKE_INSTALL_PREFIX=/usr \
+          cmake -S . -B build \
             -D CMAKE_BUILD_TYPE=RelWithDebInfo \
-            -D LINUX_PORTABLE=OFF \
             -D CPACK_DEBIAN_PACKAGE_SHLIBDEPS=ON \
             -D PKG_SUFFIX=-obs${{ matrix.obs }}-${{ matrix.ubuntu }}-x86_64 \
-            "${cmake_opt[@]}"
+            ${{ steps.obsdeps.outputs.PLUGIN_CMAKE_OPTIONS }}
+          cd build
           make -j4
           make package
           echo "FILE_NAME=$(find $PWD -name '*.deb' | head -n 1)" >> $GITHUB_ENV
@@ -80,12 +62,8 @@ jobs:
         run: |
           . build/ci/ci_includes.generated.sh
           set -ex
-          sudo apt install '${{ env.FILE_NAME }}'
-          case ${{ matrix.obs }} in
-            27) plugins_dir=/usr/lib/obs-plugins ;;
-            28) plugins_dir=/usr/lib/x86_64-linux-gnu/obs-plugins ;;
-          esac
-          ldd $plugins_dir/${PLUGIN_NAME}.so > ldd.out
+          sudo apt install -y '${{ env.FILE_NAME }}'
+          ldd /usr/lib/x86_64-linux-gnu/obs-plugins/${PLUGIN_NAME}.so > ldd.out
           if grep not.found ldd.out ; then
             echo "Error: unresolved shared object." >&2
             exit 1
@@ -97,11 +75,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - obs: 27
-            arch: x86_64
-          - obs: 28
-            arch: universal
+        obs: [30]
+        arch: ['universal']
     defaults:
       run:
         shell: bash
@@ -151,7 +126,7 @@ jobs:
 
       - name: Download obs-studio development environment
         id: obsdeps
-        uses: norihiro/obs-studio-devel-action@v1-beta
+        uses: norihiro/obs-studio-devel-action@v2
         with:
           path: /tmp/deps-${{ matrix.obs }}-${{ matrix.arch }}
           arch: ${{ matrix.arch }}
@@ -163,30 +138,16 @@ jobs:
           arch=${{ matrix.arch }}
           deps=/tmp/deps-${{ matrix.obs }}-${{ matrix.arch }}
           MACOSX_DEPLOYMENT_TARGET=${{ steps.obsdeps.outputs.MACOSX_DEPLOYMENT_TARGET }}
-          OBS_QT_VERSION_MAJOR=${{ steps.obsdeps.outputs.OBS_QT_VERSION_MAJOR }}
           GIT_TAG=$(git describe --tags --always)
           PKG_SUFFIX=-${GIT_TAG}-obs${{ matrix.obs }}-macos-${{ matrix.arch }}
           set -e
-          case "${{ matrix.obs }}" in
-            27)
-              cmake_opt=()
-              ;;
-            28)
-              cmake_opt=(
-                -D MACOSX_PLUGIN_BUNDLE_TYPE=BNDL
-                -D OBS_BUNDLE_CODESIGN_IDENTITY='${{ secrets.MACOS_SIGNING_APPLICATION_IDENTITY }}'
-              )
-              ;;
-          esac
           cmake -S . -B build -G Ninja \
-            -D QT_VERSION=$OBS_QT_VERSION_MAJOR \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_PREFIX_PATH="$PWD/release/" \
             -DCMAKE_OSX_ARCHITECTURES=${arch/#universal/x86_64;arm64} \
-            -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} \
-            -DCMAKE_FRAMEWORK_PATH="$deps/Frameworks;$deps/lib/cmake;$deps" \
             -D PKG_SUFFIX=$PKG_SUFFIX \
-            "${cmake_opt[@]}"
+            -D OBS_BUNDLE_CODESIGN_IDENTITY='${{ secrets.MACOS_SIGNING_APPLICATION_IDENTITY }}' \
+            ${{ steps.obsdeps.outputs.PLUGIN_CMAKE_OPTIONS }}
           cmake --build build --config RelWithDebInfo
 
       - name: Prepare package
@@ -194,36 +155,18 @@ jobs:
           set -ex
           . build/ci/ci_includes.generated.sh
           cmake --install build --config RelWithDebInfo --prefix=release
-          case ${{ matrix.obs }} in
-            27)
-              (cd release/${PLUGIN_NAME} && ../../ci/macos/change-rpath.sh -obs ${{ matrix.obs }} -lib lib/ bin/${PLUGIN_NAME}.so)
-              cp LICENSE release/${PLUGIN_NAME}/data/LICENSE-$PLUGIN_NAME
-              ;;
-            28)
-              (cd release/${PLUGIN_NAME}.plugin/Contents && ../../../ci/macos/change-rpath.sh -obs 28 -lib lib/ MacOS/${PLUGIN_NAME})
-              cp LICENSE release/${PLUGIN_NAME}.plugin/Contents/Resources/LICENSE-$PLUGIN_NAME
-              ;;
-          esac
+          (cd release/${PLUGIN_NAME}.plugin/Contents && ../../../ci/macos/change-rpath.sh -obs ${{ matrix.obs }} -lib lib/ MacOS/${PLUGIN_NAME})
+          cp LICENSE release/${PLUGIN_NAME}.plugin/Contents/Resources/LICENSE-$PLUGIN_NAME
 
       - name: Codesign
         if: ${{ github.event_name != 'pull_request' && steps.setup.outputs.haveCodesignIdent == 'true' }}
         run: |
           . build/ci/ci_includes.generated.sh
           set -ex
-          case ${{ matrix.obs }} in
-            27)
-              files=(
-                $(find release/${PLUGIN_NAME}/ -name '*.dylib')
-                release/${PLUGIN_NAME}/bin/${PLUGIN_NAME}.so
-              )
-              ;;
-            28)
-              files=(
-                $(find release/${PLUGIN_NAME}.plugin/ -name '*.dylib')
-                release/${PLUGIN_NAME}.plugin/Contents/MacOS/${PLUGIN_NAME}
-              )
-              ;;
-          esac
+          files=(
+            $(find release/${PLUGIN_NAME}.plugin/ -name '*.dylib')
+            release/${PLUGIN_NAME}.plugin/Contents/MacOS/${PLUGIN_NAME}
+          )
           for dylib in "${files[@]}"; do
             codesign --force --sign "${{ secrets.MACOS_SIGNING_APPLICATION_IDENTITY }}" "$dylib"
           done
@@ -237,10 +180,7 @@ jobs:
           set -ex
           zipfile=$PWD/package/${PLUGIN_NAME}${PKG_SUFFIX}.zip
           mkdir package
-          case ${{ matrix.obs }} in
-            27) (cd release/ && zip -r $zipfile ${PLUGIN_NAME}) ;;
-            28) (cd release/ && zip -r $zipfile ${PLUGIN_NAME}.plugin) ;;
-          esac
+          (cd release/ && zip -r $zipfile ${PLUGIN_NAME}.plugin)
           ci/macos/install-packagesbuild.sh
           packagesbuild \
             --build-folder $PWD/package/ \
@@ -275,7 +215,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        obs: [27, 28]
+        obs: [30]
         arch: [x64]
     env:
       visualStudio: 'Visual Studio 17 2022'
@@ -290,19 +230,16 @@ jobs:
           submodules: recursive
       - name: Download obs-studio
         id: obsdeps
-        uses: norihiro/obs-studio-devel-action@v1-beta
+        uses: norihiro/obs-studio-devel-action@v2
         with:
           obs: ${{ matrix.obs }}
       - name: Build plugin
         run: |
           $CmakeArgs = @(
             '-G', "${{ env.visualStudio }}"
-            '-DQT_VERSION=${{ steps.obsdeps.outputs.OBS_QT_VERSION_MAJOR }}'
             '-DCMAKE_SYSTEM_VERSION=10.0.18363.657'
-            "-DCMAKE_INSTALL_PREFIX=$(Resolve-Path -Path "./obs-build-dependencies/plugin-deps-${{ matrix.arch }}")"
-            "-DCMAKE_PREFIX_PATH=$(Resolve-Path -Path "./obs-build-dependencies/plugin-deps-${{ matrix.arch }}")"
           )
-          cmake -S . -B build @CmakeArgs
+          cmake -S . -B build ${{ steps.obsdeps.outputs.PLUGIN_CMAKE_OPTIONS_PS }} @CmakeArgs
           cmake --build build --config RelWithDebInfo -j 4
           cmake --install build --config RelWithDebInfo --prefix "$(Resolve-Path -Path .)/release"
       - name: Package plugin

--- a/src/scope-dock-new-dialog.cpp
+++ b/src/scope-dock-new-dialog.cpp
@@ -56,7 +56,7 @@ void ScopeDockNewDialog::accept()
 	obs_data_set_obj(props, "colormonitor_roi-prop", roi_prop);
 	ScopeWidget::default_properties(props);
 
-	scope_dock_add(editTitle->text().toUtf8().constData(), props);
+	scope_dock_add(editTitle->text().toUtf8().constData(), props, true);
 
 	obs_data_release(roi_prop);
 	obs_data_release(props);

--- a/src/scope-dock.cpp
+++ b/src/scope-dock.cpp
@@ -2,6 +2,7 @@
 #include <obs-frontend-api.h>
 #include <QAction>
 #include <QMainWindow>
+#include <QDockWidget>
 #include "plugin-macros.generated.h"
 #include "scope-dock.hpp"
 #include "scope-dock-new-dialog.hpp"
@@ -10,18 +11,7 @@
 #define SAVE_DATA_NAME PLUGIN_NAME "-dock"
 #define OBJ_NAME_SUFFIX "_scope_dock"
 
-#if LIBOBS_API_VER < MAKE_SEMANTIC_VERSION(30, 0, 0)
-void ScopeDock::closeEvent(QCloseEvent *event)
-{
-	QDockWidget::closeEvent(event);
-}
-#endif
-
-#if LIBOBS_API_VER < MAKE_SEMANTIC_VERSION(30, 0, 0)
-static std::vector<ScopeDock *> *docks;
-#else
 static std::vector<ScopeWidget *> *docks;
-#endif
 
 static inline bool is_program_dock(obs_data_t *props)
 {
@@ -39,28 +29,6 @@ static inline bool is_program_dock(obs_data_t *props)
 void scope_dock_add(const char *name, obs_data_t *props, bool show)
 {
 	auto *main_window = static_cast<QMainWindow *>(obs_frontend_get_main_window());
-#if LIBOBS_API_VER < MAKE_SEMANTIC_VERSION(30, 0, 0)
-	UNUSED_PARAMETER(show);
-	auto *dock = new ScopeDock(main_window);
-	dock->name = name;
-	dock->setObjectName(QString::fromUtf8(name) + OBJ_NAME_SUFFIX);
-	dock->setWindowTitle(name);
-	dock->resize(256, 256);
-	dock->setMinimumSize(128, 128);
-	dock->setAllowedAreas(Qt::AllDockWidgetAreas);
-
-	ScopeWidget *w = new ScopeWidget(dock);
-	dock->SetWidget(w);
-	w->load_properties(props);
-
-	auto flag = is_program_dock(props) ? Qt::RightDockWidgetArea : Qt::LeftDockWidgetArea;
-
-	main_window->addDockWidget(flag, dock);
-	dock->action = (QAction *)obs_frontend_add_dock(dock);
-
-	if (docks)
-		docks->push_back(dock);
-#else
 	ScopeWidget *w = new ScopeWidget(main_window);
 	w->name = name;
 	w->load_properties(props);
@@ -85,41 +53,7 @@ void scope_dock_add(const char *name, obs_data_t *props, bool show)
 			},
 			Qt::QueuedConnection);
 	}
-
-#endif
 }
-
-#if LIBOBS_API_VER < MAKE_SEMANTIC_VERSION(30, 0, 0)
-ScopeDock::ScopeDock(QWidget *parent) : QDockWidget(parent)
-{
-	setAttribute(Qt::WA_DeleteOnClose);
-}
-
-ScopeDock::~ScopeDock()
-{
-	if (action)
-		delete action;
-	if (docks)
-		for (size_t i = 0; i < docks->size(); i++) {
-			if ((*docks)[i] == this) {
-				docks->erase(docks->begin() + i);
-				break;
-			}
-		}
-}
-
-void ScopeDock::showEvent(QShowEvent *)
-{
-	blog(LOG_INFO, "ScopeDock::showEvent");
-	widget->setShown(true);
-}
-
-void ScopeDock::hideEvent(QHideEvent *)
-{
-	blog(LOG_INFO, "ScopeDock::hideEvent");
-	widget->setShown(false);
-}
-#endif
 
 static void close_all_docks()
 {
@@ -142,14 +76,8 @@ static void save_load_scope_docks(obs_data_t *save_data, bool saving, void *)
 		obs_data_t *props = obs_data_create();
 		obs_data_array_t *array = obs_data_array_create();
 		for (size_t i = 0; i < docks->size(); i++) {
-#if LIBOBS_API_VER < MAKE_SEMANTIC_VERSION(30, 0, 0)
-			ScopeDock *d = (*docks)[i];
-			ScopeWidget *w = d->widget;
-			const char *name = d->name.c_str();
-#else
 			ScopeWidget *w = (*docks)[i];
 			const char *name = w->name.c_str();
-#endif
 			obs_data_t *obj = obs_data_create();
 			w->save_properties(obj);
 			obs_data_set_string(obj, "name", name);
@@ -192,9 +120,7 @@ static void scope_docks_release();
 static void frontend_event(enum obs_frontend_event event, void *)
 {
 	switch (event) {
-#if LIBOBS_API_VER >= MAKE_SEMANTIC_VERSION(28, 0, 0)
 	case OBS_FRONTEND_EVENT_SCRIPTING_SHUTDOWN:
-#endif
 	case OBS_FRONTEND_EVENT_SCENE_COLLECTION_CLEANUP:
 	case OBS_FRONTEND_EVENT_EXIT:
 		close_all_docks();
@@ -209,11 +135,7 @@ static void frontend_event(enum obs_frontend_event event, void *)
 
 void scope_docks_init()
 {
-#if LIBOBS_API_VER < MAKE_SEMANTIC_VERSION(30, 0, 0)
-	docks = new std::vector<ScopeDock *>;
-#else
 	docks = new std::vector<ScopeWidget *>;
-#endif
 	obs_frontend_add_save_callback(save_load_scope_docks, NULL);
 	obs_frontend_add_event_callback(frontend_event, nullptr);
 
@@ -238,7 +160,6 @@ void scope_docks_release()
 	obs_frontend_remove_event_callback(frontend_event, nullptr);
 }
 
-#if LIBOBS_API_VER >= MAKE_SEMANTIC_VERSION(30, 0, 0)
 void scope_dock_deleted(class ScopeWidget *widget)
 {
 	if (!docks)
@@ -252,4 +173,3 @@ void scope_dock_deleted(class ScopeWidget *widget)
 		break;
 	}
 }
-#endif

--- a/src/scope-dock.hpp
+++ b/src/scope-dock.hpp
@@ -1,38 +1,5 @@
 #pragma once
 
-#include <QDockWidget>
-#include <QPointer>
-#include <QAction>
-#include <string>
-
-#if LIBOBS_API_VER < MAKE_SEMANTIC_VERSION(30, 0, 0)
-class ScopeDock : public QDockWidget {
-	Q_OBJECT
-
-public:
-	class ScopeWidget *widget;
-	std::string name;
-	QPointer<QAction> action = 0;
-
-public:
-	ScopeDock(QWidget *parent = nullptr);
-	~ScopeDock();
-	void closeEvent(QCloseEvent *event) override;
-
-	void SetWidget(class ScopeWidget *w)
-	{
-		widget = w;
-		setWidget((QWidget *)w);
-	}
-
-private:
-	void showEvent(QShowEvent *event) override;
-	void hideEvent(QHideEvent *event) override;
-};
-#endif
-
 extern "C" void scope_dock_add(const char *name, obs_data_t *props, bool show);
-#if LIBOBS_API_VER >= MAKE_SEMANTIC_VERSION(30, 0, 0)
 extern "C" void scope_dock_deleted(class ScopeWidget *);
-#endif
 extern "C" void scope_docks_init();

--- a/src/scope-dock.hpp
+++ b/src/scope-dock.hpp
@@ -5,6 +5,7 @@
 #include <QAction>
 #include <string>
 
+#if LIBOBS_API_VER < MAKE_SEMANTIC_VERSION(30, 0, 0)
 class ScopeDock : public QDockWidget {
 	Q_OBJECT
 
@@ -28,6 +29,10 @@ private:
 	void showEvent(QShowEvent *event) override;
 	void hideEvent(QHideEvent *event) override;
 };
+#endif
 
-extern "C" void scope_dock_add(const char *name, obs_data_t *props);
+extern "C" void scope_dock_add(const char *name, obs_data_t *props, bool show);
+#if LIBOBS_API_VER >= MAKE_SEMANTIC_VERSION(30, 0, 0)
+extern "C" void scope_dock_deleted(class ScopeWidget *);
+#endif
 extern "C" void scope_docks_init();

--- a/src/scope-widget.cpp
+++ b/src/scope-widget.cpp
@@ -191,9 +191,7 @@ ScopeWidget::ScopeWidget(QWidget *parent) : QWidget(parent)
 
 ScopeWidget::~ScopeWidget()
 {
-#if LIBOBS_API_VER >= MAKE_SEMANTIC_VERSION(30, 0, 0)
 	scope_dock_deleted(this);
-#endif
 
 	if (data) {
 		DestroyDisplay();
@@ -286,12 +284,10 @@ void ScopeWidget::closeEvent(QCloseEvent *)
 	setShown(false);
 }
 
-#if LIBOBS_API_VER >= MAKE_SEMANTIC_VERSION(30, 0, 0)
 void ScopeWidget::RemoveDock()
 {
 	obs_frontend_remove_dock(name.c_str());
 }
-#endif
 
 void ScopeWidget::setShown(bool shown)
 {
@@ -541,12 +537,7 @@ bool ScopeWidget::openMenu(QMouseEvent *)
 	popup.addAction(act);
 
 	act = new QAction(obs_module_text("dock.menu.close"), this);
-#if LIBOBS_API_VER < MAKE_SEMANTIC_VERSION(30, 0, 0)
-	connect(act, &QAction::triggered, this,
-		[&]() { QMetaObject::invokeMethod(parentWidget(), "close", Qt::QueuedConnection); });
-#else
 	connect(act, &QAction::triggered, this, &ScopeWidget::RemoveDock, Qt::QueuedConnection);
-#endif
 	popup.addAction(act);
 
 	popup.exec(QCursor::pos());

--- a/src/scope-widget.hpp
+++ b/src/scope-widget.hpp
@@ -3,6 +3,7 @@
 #include <obs.h>
 #include <QWidget>
 #include <memory>
+#include <string>
 
 #define SCOPE_WIDGET_N_SRC 6
 
@@ -12,10 +13,8 @@ class ScopeWidget : public QWidget {
 	struct scope_widget_s *data;
 	class ScopeWidgetProperties *properties;
 
-#if LIBOBS_API_VER >= MAKE_SEMANTIC_VERSION(30, 0, 0)
 public:
 	std::string name;
-#endif
 
 private:
 	void resizeEvent(QResizeEvent *event) override;
@@ -32,9 +31,7 @@ private:
 
 public slots:
 	void createProperties();
-#if LIBOBS_API_VER >= MAKE_SEMANTIC_VERSION(30, 0, 0)
 	void RemoveDock();
-#endif
 
 public:
 	ScopeWidget(QWidget *parent);

--- a/src/scope-widget.hpp
+++ b/src/scope-widget.hpp
@@ -12,6 +12,12 @@ class ScopeWidget : public QWidget {
 	struct scope_widget_s *data;
 	class ScopeWidgetProperties *properties;
 
+#if LIBOBS_API_VER >= MAKE_SEMANTIC_VERSION(30, 0, 0)
+public:
+	std::string name;
+#endif
+
+private:
 	void resizeEvent(QResizeEvent *event) override;
 	void paintEvent(QPaintEvent *event) override;
 	class QPaintEngine *paintEngine() const override;
@@ -26,6 +32,9 @@ class ScopeWidget : public QWidget {
 
 public slots:
 	void createProperties();
+#if LIBOBS_API_VER >= MAKE_SEMANTIC_VERSION(30, 0, 0)
+	void RemoveDock();
+#endif
 
 public:
 	ScopeWidget(QWidget *parent);


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

- src: Use `obs_frontend_add_dock_by_id`
- src: Remove legacy code for obs-studio 29 and earlier.
- .github: Use obs-studio-devel-action@v2
- .github: Drop supporting obs-studio 27, 28, 29.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [ ] The commit is reviewed by yourself.
- [ ] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [ ] The commit is compatible with repository's license.
