### PR TITLE
Clear texture before rendering to RGB and YUV

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -175,6 +175,11 @@ static bool render_rgb_yuv(struct cm_source *src, struct cm_surface_queue_item *
 	gs_texrender_reset(item->texrender);
 	if (src->effect && gs_texrender_begin(item->texrender, item->width, item->sheight)) {
 		PROFILE_START(prof_convert_yuv_name);
+
+		struct vec4 background;
+		vec4_zero(&background);
+		gs_clear(GS_CLEAR_COLOR, &background, 0.0f, 0);
+
 		gs_projection_push();
 		gs_ortho(0.0f, (float)item->width, 0.0f, (float)item->sheight, -100.0f, 100.0f);
 


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

At one of the rendering stages, it was missing to clear the texture. Due to this, the previous texture appeared in the views on the dock.

Fixes #100.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

OS: Fedora 39

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
