### PR TITLE
Update QTToGSWindow for OBS Studio 31

### DIFF
--- a/src-obsstudio/qt-wrappers.hpp
+++ b/src-obsstudio/qt-wrappers.hpp
@@ -35,8 +35,6 @@ class QLayout;
 class QString;
 struct gs_window;
 
-void QTToGSWindow(WId windowId, gs_window &gswindow);
-
 static inline Qt::ConnectionType WaitConnection()
 {
 	return QThread::currentThread() == qApp->thread()

--- a/src/obsgui-helper.hpp
+++ b/src/obsgui-helper.hpp
@@ -7,7 +7,7 @@
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-// copied from obs-studio/UI/qt-wrappers.cpp and modified to support OBS-26
+// copied from obs-studio/frontend/widgets/OBSQTDisplay.cpp
 static inline bool QTToGSWindow(QWindow *window, gs_window &gswindow)
 {
 	bool success = true;
@@ -17,22 +17,23 @@ static inline bool QTToGSWindow(QWindow *window, gs_window &gswindow)
 #elif __APPLE__
 	gswindow.view = (id)window->winId();
 #else
-#ifdef ENABLE_WAYLAND
 	switch (obs_get_nix_platform()) {
-	case OBS_NIX_PLATFORM_X11_GLX:
 	case OBS_NIX_PLATFORM_X11_EGL:
-#endif // ENABLE_WAYLAND
 		gswindow.id = window->winId();
 		gswindow.display = obs_get_nix_platform_display();
-#ifdef ENABLE_WAYLAND
 		break;
-	case OBS_NIX_PLATFORM_WAYLAND:
+#ifdef ENABLE_WAYLAND
+	case OBS_NIX_PLATFORM_WAYLAND: {
 		QPlatformNativeInterface *native = QGuiApplication::platformNativeInterface();
 		gswindow.display = native->nativeResourceForWindow("surface", window);
 		success = gswindow.display != nullptr;
 		break;
 	}
-#endif // ENABLE_WAYLAND
+#endif
+	default:
+		success = false;
+		break;
+	}
 #endif
 	return success;
 }


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

This PR includes these changes.

- Removed deprecated enum value `OBS_NIX_PLATFORM_X11_GLX`.
- Removed unused function declaration.

Fix #106.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

Confirmed the build flow succeeded on Fedora 40.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
