### PR TITLE
.github(Fedora): Add RPM build flow for Fedora 41 and remove 39

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -24,8 +24,8 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - fedora39
           - fedora40
+          - fedora41
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

- Added Fedora 41 RPM build flow
- Dropped Fedora 39 RPM build flow

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

Tested `obs-studio-plugin-color-monitor-0.8.2-8.fc41.x86_64.rpm` generated by the CI.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
