### PR TITLE
Explicitly list GuiPrivate as dependency, for Qt 6.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
 	find_package(obs-frontend-api REQUIRED)
 	include(cmake/ObsPluginHelpers.cmake)
 	add_library(OBS::frontend-api ALIAS OBS::obs-frontend-api)
-	find_qt(VERSION ${QT_VERSION} COMPONENTS Widgets Core COMPONENTS_LINUX Gui)
+	find_qt(VERSION ${QT_VERSION} COMPONENTS Widgets Core COMPONENTS_LINUX GuiPrivate)
 endif()
 
 configure_file(


### PR DESCRIPTION
### Description

I noticed that this plugin no longer builds on NixOS with Qt 6.10:

```
cmake flags: -DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DCMAKE_INSTALL_LOCALEDIR=/nix/store/n21lg3wclslk8k725vjlkkvsb6ijrd46-obs-color-monitor-0.9.3/share/locale -DCMAKE_INSTALL_LIBEXECDIR=/nix/store/n21lg3wclslk8k725vjlkkvsb6ijrd46-obs-color-monitor-0.9.3/libexec -DCMAKE_INSTALL_LIBDIR=/nix/store/n21lg3wclslk8k725vjlkkvsb6ijrd46-obs-color-monitor-0.9.3/lib -DCMAKE_INSTALL_DOCDIR=/nix/store/n21lg3wclslk8k725vjlkkvsb6ijrd46-obs-color-monitor-0.9.3/share/doc/obs-color-monitor -DCMAKE_INSTALL_INFODIR=/nix/store/n21lg3wclslk8k725vjlkkvsb6ijrd46-obs-color-monitor-0.9.3/share/info -DCMAKE_INSTALL_MANDIR=/nix/store/n21lg3wclslk8k725vjlkkvsb6ijrd46-obs-color-monitor-0.9.3/share/man -DCMAKE_INSTALL_INCLUDEDIR=/nix/store/n21lg3wclslk8k725vjlkkvsb6ijrd46-obs-color-monitor-0.9.3/include -DCMAKE_INSTALL_SBINDIR=/nix/store/n21lg3wclslk8k725vjlkkvsb6ijrd46-obs-color-monitor-0.9.3/sbin -DCMAKE_INSTALL_BINDIR=/nix/store/n21lg3wclslk8k725vjlkkvsb6ijrd46-obs-color-monitor-0.9.3/bin -DCMAKE_INSTALL_NAME_DIR=/nix/store/n21lg3wclslk8k725vjlkkvsb6ijrd46-obs-color-monitor-0.9.3/lib -DCMAKE_POLICY_DEFAULT_CMP0025=NEW -DCMAKE_FIND_FRAMEWORK=LAST -DCMAKE_STRIP=/nix/store/x8mydcgbry214s802nzvy7fdljx404ym-gcc-wrapper-14.3.0/bin/strip -DCMAKE_RANLIB=/nix/store/x8mydcgbry214s802nzvy7fdljx404ym-gcc-wrapper-14.3.0/bin/ranlib -DCMAKE_AR=/nix/store/x8mydcgbry214s802nzvy7fdljx404ym-gcc-wrapper-14.3.0/bin/ar -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_INSTALL_PREFIX=/nix/store/n21lg3wclslk8k725vjlkkvsb6ijrd46-obs-color-monitor-0.9.3
-- The C compiler identification is GNU 14.3.0
-- The CXX compiler identification is GNU 14.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /nix/store/x8mydcgbry214s802nzvy7fdljx404ym-gcc-wrapper-14.3.0/bin/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /nix/store/x8mydcgbry214s802nzvy7fdljx404ym-gcc-wrapper-14.3.0/bin/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found SIMDe: /nix/store/al0v0di0wrybvhnjf00dxcngx8y17p8s-simde-0.8.2/include (found version "0.8.2")
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Performing Test HAVE_STDATOMIC
-- Performing Test HAVE_STDATOMIC - Success
-- Qt version found: 6
-- Found OpenGL: /nix/store/as2rg79vk4z7frb7hy27nmadc3fp1a4j-libglvnd-1.7.0/lib/libOpenGL.so
-- Found WrapOpenGL: TRUE
-- Found WrapVulkanHeaders: /nix/store/icyb0ffm7i4sajzphnf818firkqlx71h-vulkan-headers-1.4.328.0/include
-- Configuring done (1.0s)
CMake Error at CMakeLists.txt:69 (target_link_libraries):
  Target "obs-color-monitor" links to:

    Qt::GuiPrivate

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.



-- Generating done (0.0s)
CMake Warning:
  Manually-specified variables were not used by the project:

    BUILD_TESTING
    CMAKE_EXPORT_NO_PACKAGE_REGISTRY
    CMAKE_POLICY_DEFAULT_CMP0025


CMake Generate step failed.  Build files cannot be regenerated correctly.
```

The fix was described [here](https://doc-snapshots.qt.io/qt6-6.10/qtguiprivate-module.html#details)

I think the change is not backwards compatible with older versions of Qt.

### How Has This Been Tested?
Launched OBS 32.0.1 under Sway, capturing screen via dmabuf. Added histogram source and changed the captured colors to see the histogram change.

I'm new to this plugin, so I may not have tested all features well. I just wanted to get the plugin building again, but I think the patch is correct.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
