### PR TITLE
cmake: Fix building with Qt >= 6.10 on Linux

### DIFF
--- a/cmake/ObsPluginHelpers.cmake
+++ b/cmake/ObsPluginHelpers.cmake
@@ -103,6 +103,11 @@ macro(find_qt)
 
   if("Gui" IN_LIST FIND_QT_COMPONENTS_LINUX)
     list(APPEND _QT_COMPONENTS "GuiPrivate")
+    if(Qt6_VERSION VERSION_GREATER_EQUAL "6.10.0")
+      set(QT_NO_PRIVATE_MODULE_WARNING ON)
+      find_package(Qt6 COMPONENTS GuiPrivate REQUIRED)
+      message(STATUS "called find_package(Qt6 COMPONENTS GuiPrivate REQUIRED)")
+    endif()
   endif()
 
   # Check for versionless targets of each requested component and create if necessary


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

Now Qt6 strictly requires that `GuiPrivate` is included in COMPONENTS parameter on find_package.

This supersedes #124.
See also a bug report.
- https://bugs.debian.org/1131613


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->
Confirmed the build flow succeeded on Fedora 42.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
